### PR TITLE
Unexpected filename error crash fix

### DIFF
--- a/utils/telegram/targets.py
+++ b/utils/telegram/targets.py
@@ -218,7 +218,7 @@ class TgChat(Target):
             send_function = getattr(self.client, f"send_{media_type}")
             args = [self.target.id, file_buffer]
             kwargs = {"caption": tg_message.text, "progress": custom_callback}
-            if media_type not in ("photo", "audio", "sticker"):
+            if media_type not in ("photo", "voice", "audio", "sticker"):
                 kwargs["file_name"] = file_path.name
 
             if media_type in ("sticker",):


### PR DESCRIPTION
Was crashing routinely for me. Discovered it was just voice was forgotten when making the list of media it should skip the get file name request for.